### PR TITLE
fix block_queue.h

### DIFF
--- a/log/block_queue.h
+++ b/log/block_queue.h
@@ -82,7 +82,8 @@ public:
             m_mutex.unlock();
             return false;
         }
-        value = m_array[m_front];
+        int pos = (m_front + 1) % m_max_size;
+        value = m_array[pos];
         m_mutex.unlock();
         return true;
     }


### PR DESCRIPTION
当队列有元素时，front指向的应该是队首元素的前一个，所以在取队首元素前，应该要获取m_front的后一个位置，即真正队首元素的位置。