### PR TITLE
Code refactor cgi version

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,4 +228,4 @@ Demo演示
 ------------
 Linux高性能服务器编程，游双著.
 
-感谢以下朋友的PR和帮助: [@RownH](https://github.com/RownH)，[@mapleFU](https://github.com/mapleFU)，[@ZWiley](https://github.com/ZWiley)，[@zjuHong](https://github.com/zjuHong)，[@mamil](https://github.com/mamil)，[@byfate](https://github.com/byfate)，[@MaJun827](https://github.com/MaJun827)，[@BBLiu-coder](https://github.com/BBLiu-coder)，[@smoky96](https://github.com/smoky96)，[@yfBong](https://github.com/yfBong)，[@liuwuyao](https://github.com/liuwuyao)，[@Huixxi](https://github.com/Huixxi).
+感谢以下朋友的PR和帮助: [@RownH](https://github.com/RownH)，[@mapleFU](https://github.com/mapleFU)，[@ZWiley](https://github.com/ZWiley)，[@zjuHong](https://github.com/zjuHong)，[@mamil](https://github.com/mamil)，[@byfate](https://github.com/byfate)，[@MaJun827](https://github.com/MaJun827)，[@BBLiu-coder](https://github.com/BBLiu-coder)，[@smoky96](https://github.com/smoky96)，[@yfBong](https://github.com/yfBong)，[@liuwuyao](https://github.com/liuwuyao)，[@Huixxi](https://github.com/Huixxi)，[@ning2510](https://github.com/ning2510).

--- a/http/http_conn.cpp
+++ b/http/http_conn.cpp
@@ -752,7 +752,7 @@ bool http_conn::write()
         else
         {
             m_iv[0].iov_base = m_write_buf + bytes_have_send;
-            m_iv[0].iov_len = m_iv[0].iov_len - bytes_have_send;
+            m_iv[0].iov_len = m_iv[0].iov_len - temp;
         }
 
         if (bytes_to_send <= 0)


### PR DESCRIPTION
[问题所在](https://github.com/qinguoyi/TinyWebServer/blob/codeRefactorCGI_version/http/http_conn.cpp#L755)
如果这里减的是 `bytes_have_send`，应该是 `temp`，说一下原因：

- 如果第一个 `iovec` 的头部信息数据长度需要多次使用 `writev` 才能发送完的话，那么 `m_iv[0].iov_len` 就会重复减去相同的值
- 举个例子：假设第一个 `iovec` 的头部信息数据长度为 90，每次 `writev` 发送的长度为 30。第一次调用 `writev` 后 `m_iv[0].iov_len = m_iv[0].iov_len - 30 = 90 - 30 = 60`，第二次后 `m_iv[0].iov_len = m_iv[0].iov_len - 60 = 60 - 60 = 0`，实际还有 30 没有发送

所以应该改为 `m_iv[0].iov_len = m_iv[0].iov_len - temp;`，每次减去已经发送的长度 `temp`