### PR TITLE
fix issue #196

### DIFF
--- a/log/log.cpp
+++ b/log/log.cpp
@@ -134,7 +134,7 @@ void Log::write_log(int level, const char *format, ...)
                      my_tm.tm_year + 1900, my_tm.tm_mon + 1, my_tm.tm_mday,
                      my_tm.tm_hour, my_tm.tm_min, my_tm.tm_sec, now.tv_usec, s);
     
-    int m = vsnprintf(m_buf + n, m_log_buf_size - 1, format, valst);
+    int m = vsnprintf(m_buf + n, m_log_buf_size - n - 1, format, valst);
     m_buf[n + m] = '\n';
     m_buf[n + m + 1] = '\0';
     log_str = m_buf;


### PR DESCRIPTION
修复了#issue196提出的栈溢出漏洞。这里的问题是`m_buf`总共只有`m_log_buf_size`大小，用`vsnprintf`格式化字符串时开始的位置是`m_buf + n`，那么长度应该是`m_log_buf_size - n - 1`而不是`m_log_buf_size - 1`。