### PR TITLE
[fix] http_conn::process_write 此处应该是无资源状态，原状态未对404无资源情况进行处理

### DIFF
--- a/http/http_conn.cpp
+++ b/http/http_conn.cpp
@@ -638,7 +638,7 @@ bool http_conn::process_write(HTTP_CODE ret)
             return false;
         break;
     }
-    case BAD_REQUEST:
+    case NO_RESOURCE:
     {
         add_status_line(404, error_404_title);
         add_headers(strlen(error_404_form));


### PR DESCRIPTION
原代码会导致请求资源不存在的时候，直接关闭连接，会导致浏览器出现 连接被重置的问题。