### PR TITLE
去掉重复的定义

### DIFF
--- a/webserver.cpp
+++ b/webserver.cpp
@@ -135,7 +135,6 @@ void WebServer::eventListen()
     utils.init(TIMESLOT);
 
     //epoll创建内核事件表
-    epoll_event events[MAX_EVENT_NUMBER];
     m_epollfd = epoll_create(5);
     assert(m_epollfd != -1);
 


### PR DESCRIPTION
webserver.h文件中已经有`epoll_event events[MAX_EVENT_NUMBER];`的定义，所以可以去掉多余的定义。