### PR TITLE
Fix log write order error caused by loop queue full when using asynchronous logging system

### DIFF
--- a/log/block_queue.h
+++ b/log/block_queue.h
@@ -130,10 +130,19 @@ public:
         m_mutex.lock();
         if (m_size >= m_max_size)
         {
-
-            m_cond.broadcast();
-            m_mutex.unlock();
-            return false;
+            int new_max_size = m_max_size * 2;
+            T* new_array = new T[new_max_size];
+            // 复制旧队列元素到新队列
+            for (int i = 0; i < m_max_size; i++) {
+                new_array[i] = m_array[(m_front + i + 1) % m_max_size];
+            }
+            // 删除旧数组
+            delete[] m_array;
+            // 更新队列指针和大小
+            m_array = new_array;
+            m_front = -1;  // 重置队首位置
+            m_back = m_size - 1;  // 重置队尾位置
+            m_max_size = new_max_size;
         }
 
         m_back = (m_back + 1) % m_max_size;

--- a/log/log.cpp
+++ b/log/log.cpp
@@ -141,7 +141,7 @@ void Log::write_log(int level, const char *format, ...)
 
     m_mutex.unlock();
 
-    if (m_is_async && !m_log_queue->full())
+    if (m_is_async)
     {
         m_log_queue->push(log_str);
     }


### PR DESCRIPTION
## PR描述

修复了使用异步日志系统时由于循环队列已满造成的日志写入顺序错误

## 理由

假如日志系统使用的是异步模式，写入日志的原代码如下：

~~~c++
    if (m_is_async && !m_log_queue->full())
    {
        m_log_queue->push(log_str);
    }
    else
    {
        m_mutex.lock();
        fputs(log_str.c_str(), m_fp);
        m_mutex.unlock();
    }
~~~

此时如果循环队列已满，代码就会执行同步模式的那个分支，直接将现在产生的日志写入日志系统。但是循环队列中仍然有之前还没写入的日志，由此造成了日志写入顺序的错误和日志模式的混乱。

## 解决方法

为循环队列添加自适应扩容功能，如果循环队列已满，将自动进行扩容。此时原来的日志写入就无须判断`m_log_queue->full()`