### PR TITLE
fix: add  log function's missing return value

### DIFF
--- a/log/log.h
+++ b/log/log.h
@@ -22,7 +22,7 @@ public:
 
     static void *flush_log_thread(void *args)
     {
-        Log::get_instance()->async_write_log();
+        return Log::get_instance()->async_write_log();
     }
     //可选择的参数有日志文件、日志缓冲区大小、最大行数以及最长日志条队列
     bool init(const char *file_name, int close_log, int log_buf_size = 8192, int split_lines = 5000000, int max_queue_size = 0);
@@ -44,6 +44,8 @@ private:
             fputs(single_log.c_str(), m_fp);
             m_mutex.unlock();
         }
+
+        return nullptr;
     }
 
 private:


### PR DESCRIPTION
If we don't add a return value, the program will fail at build time